### PR TITLE
Fix typo

### DIFF
--- a/app/imports/templates/components/nameStatus.html
+++ b/app/imports/templates/components/nameStatus.html
@@ -42,7 +42,7 @@
 
         {{#if hasAuctions}}
         <br>
-        <h3> Knowns Auctions Started recently </h3>
+        <h3> Known Auctions Started recently </h3>
 
         Auctions are semi private: they are only seen by those who know the name. Some popular domains are therefore identifiable, but secret names are kept private until the owner decides to become public.
 


### PR DESCRIPTION
Remove extraneous 's' from "Known"

Current build: "KNOWNS AUCTIONS STARTED"

After this fix: "KNOWN AUCTIONS STARTED"